### PR TITLE
feat: Streamlit UI with hybrid search and administration comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Git worktrees
 .worktrees/
 
+# Brainstorm session files
+.superpowers/
+
 # Notebooks
 *.ipynb
 *.ipynb_checkpoints

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from trace_app.config import Settings
 from trace_app.frontend.comparison import get_admin_comparison
-from trace_app.frontend.search import get_rule, search_rules
+from trace_app.frontend.search import get_rule, search_rules_hybrid
 from trace_app.storage.database import build_engine, build_session_factory
 
 ADMIN_COLORS = {
@@ -89,7 +89,13 @@ if view == "Search":
     if st.button("Search") or query:
         session = _get_session()
         try:
-            results = search_rules(session, query=query, filters=filters)
+            embed_model = _get_embed_model()
+            results = search_rules_hybrid(
+                session,
+                query=query,
+                filters=filters,
+                embed_fn=lambda text: embed_model.encode(text).tolist(),
+            )
         finally:
             session.close()
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,251 @@
+"""TRACE — Streamlit UI shell. All data logic lives in trace_app.frontend."""
+
+import uuid
+
+import plotly.graph_objects as go
+import streamlit as st
+from sentence_transformers import SentenceTransformer
+from sqlalchemy.orm import Session
+
+from trace_app.config import Settings
+from trace_app.frontend.comparison import get_admin_comparison
+from trace_app.frontend.search import get_rule, search_rules
+from trace_app.storage.database import build_engine, build_session_factory
+
+ADMIN_COLORS = {
+    "Obama": "#89b4fa",
+    "Trump 1": "#fab387",
+    "Biden": "#a6e3a1",
+    "Trump 2": "#f38ba8",
+}
+
+DOC_TYPE_COLORS = {
+    "RULE": "#89b4fa",
+    "PROPOSED_RULE": "#a6e3a1",
+    "NOTICE": "#f9e2af",
+}
+
+
+@st.cache_resource
+def _get_session_factory():
+    settings = Settings()  # ty: ignore[missing-argument]
+    engine = build_engine(settings.database_url)
+    return build_session_factory(engine)
+
+
+@st.cache_resource
+def _get_embed_model():
+    settings = Settings()  # ty: ignore[missing-argument]
+    return SentenceTransformer(settings.embedding_model)
+
+
+def _get_session() -> Session:
+    factory = _get_session_factory()
+    return factory()
+
+
+# --- Sidebar navigation ---
+
+st.set_page_config(page_title="TRACE", layout="wide")
+
+view = st.sidebar.radio(
+    "Navigation",
+    ["Search", "Rule Detail", "Administration Comparison", "Graph Explorer"],
+    index=0,
+)
+
+# --- Search view ---
+
+if view == "Search":
+    st.title("Search FERC Rules")
+
+    query = st.text_input("Search", placeholder="e.g. electricity transmission rates")
+
+    with st.expander("Filters"):
+        col1, col2 = st.columns(2)
+        with col1:
+            admin_filter = st.multiselect(
+                "Administration",
+                ["Obama", "Trump 1", "Biden", "Trump 2"],
+            )
+            doc_type_filter = st.multiselect(
+                "Document Type",
+                ["RULE", "PROPOSED_RULE", "NOTICE"],
+            )
+        with col2:
+            date_from = st.date_input("From date", value=None)
+            date_to = st.date_input("To date", value=None)
+
+    filters: dict = {}
+    if admin_filter:
+        filters["administration"] = admin_filter
+    if doc_type_filter:
+        filters["document_type"] = doc_type_filter
+    if date_from:
+        filters["date_from"] = date_from
+    if date_to:
+        filters["date_to"] = date_to
+
+    if st.button("Search") or query:
+        session = _get_session()
+        try:
+            results = search_rules(session, query=query, filters=filters)
+        finally:
+            session.close()
+
+        if not results:
+            st.info("No results found.")
+        else:
+            st.caption(f"{len(results)} results")
+            for r in results:
+                admin_color = ADMIN_COLORS.get(r["administration"], "#6c7086")
+                doc_color = DOC_TYPE_COLORS.get(r["document_type"], "#6c7086")
+                with st.container(border=True):
+                    col_title, col_badges = st.columns([4, 1])
+                    with col_title:
+                        if st.button(r["title"], key=str(r["rule_id"])):
+                            st.session_state["selected_rule_id"] = str(r["rule_id"])
+                            st.session_state["nav_to_detail"] = True
+                            st.rerun()
+                    with col_badges:
+                        st.markdown(
+                            f"<span style='background:{admin_color};color:#1e1e2e;"
+                            f"padding:2px 8px;border-radius:4px;font-size:0.8em'>"
+                            f"{r['administration']}</span> "
+                            f"<span style='background:{doc_color};color:#1e1e2e;"
+                            f"padding:2px 8px;border-radius:4px;font-size:0.8em'>"
+                            f"{r['document_type']}</span>",
+                            unsafe_allow_html=True,
+                        )
+                    if r.get("abstract"):
+                        st.caption(
+                            r["abstract"][:200] + ("..." if len(r["abstract"] or "") > 200 else "")
+                        )
+                    meta_parts = [str(r["publication_date"])]
+                    if r.get("cfr_sections"):
+                        meta_parts.append(" · ".join(r["cfr_sections"]))
+                    st.caption(" · ".join(meta_parts))
+
+# --- Rule Detail view ---
+
+elif view == "Rule Detail":
+    st.title("Rule Detail")
+
+    rule_id_str = st.session_state.get("selected_rule_id")
+    if not rule_id_str:
+        st.info("Select a rule from the Search view to see its details.")
+    else:
+        session = _get_session()
+        try:
+            rule = get_rule(session, uuid.UUID(rule_id_str))
+        finally:
+            session.close()
+
+        if rule is None:
+            st.error("Rule not found.")
+        else:
+            st.header(rule["title"])
+
+            col1, col2, col3, col4 = st.columns(4)
+            col1.metric("Date", str(rule["publication_date"]))
+            col2.metric("Administration", rule["administration"])
+            col3.metric("Type", rule["document_type"])
+            col4.markdown(f"[Federal Register]({rule['fr_url']})")
+
+            if rule.get("cfr_sections"):
+                st.markdown("**CFR Sections:** " + ", ".join(rule["cfr_sections"]))
+
+            if rule.get("abstract"):
+                st.subheader("Abstract")
+                st.write(rule["abstract"])
+
+            with st.expander("Full Text"):
+                st.write(rule["full_text"])
+
+            st.subheader("Citation Graph")
+            st.info("Citation graph coming soon — pending citation extraction implementation.")
+
+# --- Administration Comparison view ---
+
+elif view == "Administration Comparison":
+    st.title("Administration Comparison")
+
+    session = _get_session()
+    try:
+        data = get_admin_comparison(session)
+    finally:
+        session.close()
+
+    if not data["counts_by_admin"]:
+        st.info("No rules in the database yet.")
+    else:
+        # Metric cards
+        cols = st.columns(len(data["admin_spans"]))
+        for i, span in enumerate(data["admin_spans"]):
+            count = data["counts_by_admin"].get(span["name"], 0)
+            cols[i].metric(span["name"], count)
+
+        # Stacked bar chart
+        admin_names = [s["name"] for s in data["admin_spans"]]
+        doc_types = sorted({dt for _, dt in data["counts_by_admin_type"]})
+
+        fig = go.Figure()
+        for dt in doc_types:
+            counts = [data["counts_by_admin_type"].get((admin, dt), 0) for admin in admin_names]
+            fig.update_layout(barmode="stack")
+            fig.add_trace(
+                go.Bar(
+                    name=dt,
+                    x=admin_names,
+                    y=counts,
+                    marker_color=DOC_TYPE_COLORS.get(dt, "#6c7086"),
+                )
+            )
+        fig.update_layout(
+            title="Rules by Type per Administration",
+            barmode="stack",
+            xaxis_title="Administration",
+            yaxis_title="Count",
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+        # Timeline
+        fig_timeline = go.Figure()
+        for span in data["admin_spans"]:
+            count = data["counts_by_admin"].get(span["name"], 0)
+            fig_timeline.add_trace(
+                go.Bar(
+                    name=span["name"],
+                    x=[(span["end"] - span["start"]).days],
+                    y=[span["name"]],
+                    orientation="h",
+                    marker_color=ADMIN_COLORS.get(span["name"], "#6c7086"),
+                    text=[f"{count} rules"],
+                    textposition="inside",
+                )
+            )
+        fig_timeline.update_layout(
+            title="Administration Timeline",
+            showlegend=False,
+            barmode="stack",
+            xaxis_title="Days in Office",
+        )
+        st.plotly_chart(fig_timeline, use_container_width=True)
+
+        # Topic drift stub
+        st.subheader("Topic Drift")
+        st.info("Topic drift analysis coming soon — pending embedding centroid computation.")
+
+# --- Graph Explorer view ---
+
+elif view == "Graph Explorer":
+    st.title("Graph Explorer")
+    st.info(
+        "Citation graph coming soon — this view will show the full FERC rule citation "
+        "network, filterable by administration and document type."
+    )
+
+# --- Handle nav-to-detail redirect ---
+
+if st.session_state.get("nav_to_detail"):
+    st.session_state["nav_to_detail"] = False

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@ Python package, Docker + Postgres 17/pgvector, Alembic, CI, pre-commit, ORM mode
 
 ---
 
-### Phase 3 — Citation Graph
+### Phase 4 — Citation Graph
 **Goal:** Populate `edges` by extracting rule-to-rule citations from full text.
 
 **Scope:**
@@ -61,7 +61,7 @@ Python package, Docker + Postgres 17/pgvector, Alembic, CI, pre-commit, ORM mode
 
 ---
 
-### Phase 4 — Streamlit UI
+### Phase 3 — Streamlit UI ✅
 **Goal:** Browser interface for search, rule detail, citation graph, and administration comparison.
 
 **Views:**

--- a/docs/superpowers/plans/2026-04-13-streamlit-ui.md
+++ b/docs/superpowers/plans/2026-04-13-streamlit-ui.md
@@ -1,0 +1,1118 @@
+# Streamlit UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a browser interface for searching FERC rules, viewing rule details, and comparing administrations. Citation graph views are stubbed.
+
+**Architecture:** Framework-agnostic data layer in `src/trace_app/frontend/` (no Streamlit imports) with a thin Streamlit rendering shell in `app.py`. All DB access through SQLAlchemy sessions. Plotly for charts.
+
+**Tech Stack:** Streamlit, Plotly, SQLAlchemy, pgvector, sentence-transformers (`all-MiniLM-L6-v2`)
+
+---
+
+### Task 1: Add Streamlit and Plotly dependencies
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add dependencies to pyproject.toml**
+
+Add `streamlit` and `plotly` to the `dependencies` list in `pyproject.toml`:
+
+```toml
+"plotly>=6.0,<7.0",
+"streamlit>=1.40,<2.0",
+```
+
+Add them after the existing `prefect` line, keeping alphabetical order within the block.
+
+- [ ] **Step 2: Sync the environment**
+
+Run:
+```bash
+uv sync --all-extras
+```
+Expected: resolves and installs streamlit, plotly, and their transitive deps without conflicts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: add streamlit and plotly dependencies"
+```
+
+---
+
+### Task 2: Implement `frontend/search.py` — `get_rule()`
+
+**Files:**
+- Create: `src/trace_app/frontend/search.py`
+- Create: `tests/unit/test_frontend_search.py`
+
+- [ ] **Step 1: Create test file with helper and first test**
+
+Create `tests/unit/test_frontend_search.py`:
+
+```python
+"""Unit tests for frontend search functions (SQLite)."""
+
+import uuid
+from datetime import UTC, date, datetime
+
+from trace_app.storage.models import Rule
+
+
+def _make_rule(**overrides) -> Rule:
+    defaults = dict(
+        rule_id=uuid.uuid4(),
+        title="Test Rule",
+        abstract="An abstract about electricity markets.",
+        full_text="Full body text about FERC regulations.",
+        publication_date=date(2021, 6, 1),
+        agency="FERC",
+        document_type="RULE",
+        administration="Biden",
+        fr_url="https://www.federalregister.gov/documents/2021/06/01/2021-11111/test",
+        fr_document_number="2021-11111",
+        content_hash="abc123",
+        ingested_at=datetime.now(UTC),
+        text_source="html_fallback",
+    )
+    defaults.update(overrides)
+    return Rule(**defaults)
+
+
+def test_get_rule_returns_matching_rule(sqlite_session):
+    rule = _make_rule()
+    sqlite_session.add(rule)
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import get_rule
+
+    result = get_rule(sqlite_session, rule.rule_id)
+    assert result is not None
+    assert result["title"] == "Test Rule"
+    assert result["rule_id"] == rule.rule_id
+
+
+def test_get_rule_returns_none_for_missing_id(sqlite_session):
+    from trace_app.frontend.search import get_rule
+
+    result = get_rule(sqlite_session, uuid.uuid4())
+    assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_frontend_search.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'trace_app.frontend.search'`
+
+- [ ] **Step 3: Implement `get_rule`**
+
+Create `src/trace_app/frontend/search.py`:
+
+```python
+"""Search and rule retrieval — framework-agnostic, no Streamlit imports."""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from trace_app.storage.models import Rule
+
+
+def _rule_to_dict(rule: Rule) -> dict:
+    return {
+        "rule_id": rule.rule_id,
+        "title": rule.title,
+        "abstract": rule.abstract,
+        "full_text": rule.full_text,
+        "publication_date": rule.publication_date,
+        "effective_date": rule.effective_date,
+        "agency": rule.agency,
+        "document_type": rule.document_type,
+        "cfr_sections": rule.cfr_sections,
+        "administration": rule.administration,
+        "fr_url": rule.fr_url,
+        "fr_document_number": rule.fr_document_number,
+        "text_source": rule.text_source,
+    }
+
+
+def get_rule(session: Session, rule_id: uuid.UUID) -> dict | None:
+    """Fetch a single rule by ID. Returns dict or None."""
+    rule = session.execute(
+        select(Rule).where(Rule.rule_id == rule_id)
+    ).scalar_one_or_none()
+    if rule is None:
+        return None
+    return _rule_to_dict(rule)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_frontend_search.py -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trace_app/frontend/search.py tests/unit/test_frontend_search.py
+git commit -m "feat: add get_rule() to frontend search module"
+```
+
+---
+
+### Task 3: Implement `frontend/search.py` — `search_rules()`
+
+**Files:**
+- Modify: `src/trace_app/frontend/search.py`
+- Modify: `tests/unit/test_frontend_search.py`
+
+This task implements keyword search only (ILIKE on title+abstract). The pgvector cosine similarity path requires Postgres and is added in Task 7 (integration test).
+
+- [ ] **Step 1: Add tests for keyword search**
+
+Append to `tests/unit/test_frontend_search.py`:
+
+```python
+def test_search_rules_keyword_matches_title(sqlite_session):
+    rule = _make_rule(title="Electricity Transmission Rates")
+    sqlite_session.add(rule)
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(sqlite_session, query="transmission", filters={})
+    assert len(results) == 1
+    assert results[0]["title"] == "Electricity Transmission Rates"
+
+
+def test_search_rules_keyword_matches_abstract(sqlite_session):
+    rule = _make_rule(abstract="Wholesale electricity market reform")
+    sqlite_session.add(rule)
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(sqlite_session, query="wholesale", filters={})
+    assert len(results) == 1
+
+
+def test_search_rules_no_match_returns_empty(sqlite_session):
+    rule = _make_rule()
+    sqlite_session.add(rule)
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(sqlite_session, query="nonexistent_xyz", filters={})
+    assert results == []
+
+
+def test_search_rules_filters_by_administration(sqlite_session):
+    r1 = _make_rule(
+        administration="Biden",
+        fr_document_number="2021-11111",
+        content_hash="hash1",
+    )
+    r2 = _make_rule(
+        administration="Trump 1",
+        fr_document_number="2019-22222",
+        content_hash="hash2",
+        title="Another Rule",
+    )
+    sqlite_session.add_all([r1, r2])
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(
+        sqlite_session,
+        query="rule",
+        filters={"administration": ["Biden"]},
+    )
+    assert len(results) == 1
+    assert results[0]["administration"] == "Biden"
+
+
+def test_search_rules_filters_by_document_type(sqlite_session):
+    r1 = _make_rule(
+        document_type="RULE",
+        fr_document_number="2021-11111",
+        content_hash="hash1",
+    )
+    r2 = _make_rule(
+        document_type="NOTICE",
+        fr_document_number="2021-22222",
+        content_hash="hash2",
+        title="A Notice",
+    )
+    sqlite_session.add_all([r1, r2])
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(
+        sqlite_session,
+        query="",
+        filters={"document_type": ["RULE"]},
+    )
+    assert len(results) == 1
+    assert results[0]["document_type"] == "RULE"
+
+
+def test_search_rules_empty_query_returns_all(sqlite_session):
+    r1 = _make_rule(fr_document_number="2021-11111", content_hash="hash1")
+    r2 = _make_rule(
+        fr_document_number="2021-22222",
+        content_hash="hash2",
+        title="Second Rule",
+    )
+    sqlite_session.add_all([r1, r2])
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(sqlite_session, query="", filters={})
+    assert len(results) == 2
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `uv run pytest tests/unit/test_frontend_search.py -v`
+Expected: new tests FAIL with `ImportError` or `AttributeError` (search_rules not defined)
+
+- [ ] **Step 3: Implement `search_rules`**
+
+Add to `src/trace_app/frontend/search.py`:
+
+```python
+from sqlalchemy import or_
+
+
+def search_rules(
+    session: Session,
+    query: str,
+    filters: dict,
+    limit: int = 20,
+) -> list[dict]:
+    """Keyword search on title+abstract with optional filters.
+
+    Semantic search (pgvector cosine similarity) is added when an embed_fn
+    is provided — see search_rules_hybrid() for the full hybrid path.
+    """
+    stmt = select(Rule)
+
+    if query.strip():
+        pattern = f"%{query.strip()}%"
+        stmt = stmt.where(
+            or_(
+                Rule.title.ilike(pattern),
+                Rule.abstract.ilike(pattern),
+            )
+        )
+
+    if admins := filters.get("administration"):
+        stmt = stmt.where(Rule.administration.in_(admins))
+
+    if doc_types := filters.get("document_type"):
+        stmt = stmt.where(Rule.document_type.in_(doc_types))
+
+    if date_from := filters.get("date_from"):
+        stmt = stmt.where(Rule.publication_date >= date_from)
+
+    if date_to := filters.get("date_to"):
+        stmt = stmt.where(Rule.publication_date <= date_to)
+
+    stmt = stmt.order_by(Rule.publication_date.desc()).limit(limit)
+    rules = session.execute(stmt).scalars().all()
+    return [_rule_to_dict(r) for r in rules]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_frontend_search.py -v`
+Expected: all 8 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trace_app/frontend/search.py tests/unit/test_frontend_search.py
+git commit -m "feat: add search_rules() with keyword search and filters"
+```
+
+---
+
+### Task 4: Implement `frontend/comparison.py`
+
+**Files:**
+- Create: `src/trace_app/frontend/comparison.py`
+- Create: `tests/unit/test_frontend_comparison.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/unit/test_frontend_comparison.py`:
+
+```python
+"""Unit tests for administration comparison functions (SQLite)."""
+
+import uuid
+from datetime import UTC, date, datetime
+
+from trace_app.storage.models import Rule
+
+
+def _make_rule(**overrides) -> Rule:
+    defaults = dict(
+        rule_id=uuid.uuid4(),
+        title="Test Rule",
+        abstract="Abstract text.",
+        full_text="Full body text.",
+        publication_date=date(2021, 6, 1),
+        agency="FERC",
+        document_type="RULE",
+        administration="Biden",
+        fr_url="https://www.federalregister.gov/documents/2021/06/01/2021-11111/test",
+        fr_document_number="2021-11111",
+        content_hash="abc123",
+        ingested_at=datetime.now(UTC),
+        text_source="html_fallback",
+    )
+    defaults.update(overrides)
+    return Rule(**defaults)
+
+
+def test_get_admin_comparison_empty_db(sqlite_session):
+    from trace_app.frontend.comparison import get_admin_comparison
+
+    result = get_admin_comparison(sqlite_session)
+    assert result["counts_by_admin"] == {}
+    assert result["counts_by_admin_type"] == {}
+
+
+def test_get_admin_comparison_counts_by_admin(sqlite_session):
+    r1 = _make_rule(
+        administration="Biden",
+        fr_document_number="2021-11111",
+        content_hash="h1",
+    )
+    r2 = _make_rule(
+        administration="Biden",
+        fr_document_number="2021-22222",
+        content_hash="h2",
+        document_type="NOTICE",
+    )
+    r3 = _make_rule(
+        administration="Trump 1",
+        fr_document_number="2019-33333",
+        content_hash="h3",
+    )
+    sqlite_session.add_all([r1, r2, r3])
+    sqlite_session.flush()
+
+    from trace_app.frontend.comparison import get_admin_comparison
+
+    result = get_admin_comparison(sqlite_session)
+    assert result["counts_by_admin"]["Biden"] == 2
+    assert result["counts_by_admin"]["Trump 1"] == 1
+
+
+def test_get_admin_comparison_counts_by_admin_type(sqlite_session):
+    r1 = _make_rule(
+        administration="Biden",
+        document_type="RULE",
+        fr_document_number="2021-11111",
+        content_hash="h1",
+    )
+    r2 = _make_rule(
+        administration="Biden",
+        document_type="NOTICE",
+        fr_document_number="2021-22222",
+        content_hash="h2",
+    )
+    sqlite_session.add_all([r1, r2])
+    sqlite_session.flush()
+
+    from trace_app.frontend.comparison import get_admin_comparison
+
+    result = get_admin_comparison(sqlite_session)
+    assert result["counts_by_admin_type"][("Biden", "RULE")] == 1
+    assert result["counts_by_admin_type"][("Biden", "NOTICE")] == 1
+
+
+def test_get_admin_comparison_includes_admin_spans(sqlite_session):
+    from trace_app.frontend.comparison import get_admin_comparison
+
+    result = get_admin_comparison(sqlite_session)
+    spans = result["admin_spans"]
+    assert len(spans) == 4
+    assert spans[0]["name"] == "Obama"
+    assert spans[-1]["name"] == "Trump 2"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_frontend_comparison.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Implement `get_admin_comparison`**
+
+Create `src/trace_app/frontend/comparison.py`:
+
+```python
+"""Administration comparison queries — framework-agnostic, no Streamlit imports."""
+
+from collections import defaultdict
+from datetime import date
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from trace_app.storage.models import Rule
+
+ADMIN_SPANS = [
+    {"name": "Obama", "start": date(2009, 1, 20), "end": date(2017, 1, 19)},
+    {"name": "Trump 1", "start": date(2017, 1, 20), "end": date(2021, 1, 19)},
+    {"name": "Biden", "start": date(2021, 1, 20), "end": date(2025, 1, 19)},
+    {"name": "Trump 2", "start": date(2025, 1, 20), "end": date(2029, 1, 19)},
+]
+
+
+def get_admin_comparison(session: Session) -> dict:
+    """Return rule counts and breakdowns by administration.
+
+    Returns:
+        {
+            "counts_by_admin": {"Biden": 42, ...},
+            "counts_by_admin_type": {("Biden", "RULE"): 30, ...},
+            "admin_spans": [{"name": ..., "start": ..., "end": ...}, ...],
+        }
+    """
+    rows = session.execute(
+        select(
+            Rule.administration,
+            Rule.document_type,
+            func.count().label("cnt"),
+        ).group_by(Rule.administration, Rule.document_type)
+    ).all()
+
+    counts_by_admin: dict[str, int] = defaultdict(int)
+    counts_by_admin_type: dict[tuple[str, str], int] = {}
+
+    for admin, doc_type, cnt in rows:
+        counts_by_admin[admin] += cnt
+        counts_by_admin_type[(admin, doc_type)] = cnt
+
+    return {
+        "counts_by_admin": dict(counts_by_admin),
+        "counts_by_admin_type": counts_by_admin_type,
+        "admin_spans": ADMIN_SPANS,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_frontend_comparison.py -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trace_app/frontend/comparison.py tests/unit/test_frontend_comparison.py
+git commit -m "feat: add get_admin_comparison() for administration comparison view"
+```
+
+---
+
+### Task 5: Implement `frontend/graph.py` — stubs
+
+**Files:**
+- Create: `src/trace_app/frontend/graph.py`
+- Create: `tests/unit/test_frontend_graph.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/unit/test_frontend_graph.py`:
+
+```python
+"""Unit tests for graph stubs."""
+
+import uuid
+
+
+def test_get_citation_subgraph_returns_stub(sqlite_session):
+    from trace_app.frontend.graph import get_citation_subgraph
+
+    result = get_citation_subgraph(sqlite_session, uuid.uuid4())
+    assert result == {"stub": True}
+
+
+def test_get_full_graph_returns_stub(sqlite_session):
+    from trace_app.frontend.graph import get_full_graph
+
+    result = get_full_graph(sqlite_session)
+    assert result == {"stub": True}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_frontend_graph.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Implement stubs**
+
+Create `src/trace_app/frontend/graph.py`:
+
+```python
+"""Citation graph queries — stubs pending citation graph implementation."""
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+
+def get_citation_subgraph(session: Session, rule_id: uuid.UUID) -> dict:
+    """Return 1-hop citation subgraph for a rule. Stub."""
+    return {"stub": True}
+
+
+def get_full_graph(session: Session) -> dict:
+    """Return the full citation graph. Stub."""
+    return {"stub": True}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_frontend_graph.py -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trace_app/frontend/graph.py tests/unit/test_frontend_graph.py
+git commit -m "feat: add stubbed citation graph functions"
+```
+
+---
+
+### Task 6: Build `app.py` — Streamlit rendering shell
+
+**Files:**
+- Create: `app.py` (project root)
+
+This is the Streamlit entry point. It imports the `frontend/` data layer functions and renders results using `st.*` calls. No unit tests — this is pure rendering.
+
+- [ ] **Step 1: Create `app.py`**
+
+Create `app.py` at the project root:
+
+```python
+"""TRACE — Streamlit UI shell. All data logic lives in trace_app.frontend."""
+
+import uuid
+
+import plotly.graph_objects as go
+import streamlit as st
+from sentence_transformers import SentenceTransformer
+from sqlalchemy.orm import Session
+
+from trace_app.config import Settings
+from trace_app.frontend.comparison import get_admin_comparison
+from trace_app.frontend.graph import get_citation_subgraph, get_full_graph
+from trace_app.frontend.search import get_rule, search_rules
+from trace_app.storage.database import build_engine, build_session_factory
+
+ADMIN_COLORS = {
+    "Obama": "#89b4fa",
+    "Trump 1": "#fab387",
+    "Biden": "#a6e3a1",
+    "Trump 2": "#f38ba8",
+}
+
+DOC_TYPE_COLORS = {
+    "RULE": "#89b4fa",
+    "PROPOSED_RULE": "#a6e3a1",
+    "NOTICE": "#f9e2af",
+}
+
+
+@st.cache_resource
+def _get_session_factory():
+    settings = Settings()
+    engine = build_engine(settings.database_url)
+    return build_session_factory(engine)
+
+
+@st.cache_resource
+def _get_embed_model():
+    settings = Settings()
+    return SentenceTransformer(settings.embedding_model)
+
+
+def _get_session() -> Session:
+    factory = _get_session_factory()
+    return factory()
+
+
+# --- Sidebar navigation ---
+
+st.set_page_config(page_title="TRACE", layout="wide")
+
+view = st.sidebar.radio(
+    "Navigation",
+    ["Search", "Rule Detail", "Administration Comparison", "Graph Explorer"],
+    index=0,
+)
+
+# --- Search view ---
+
+if view == "Search":
+    st.title("Search FERC Rules")
+
+    query = st.text_input("Search", placeholder="e.g. electricity transmission rates")
+
+    with st.expander("Filters"):
+        col1, col2 = st.columns(2)
+        with col1:
+            admin_filter = st.multiselect(
+                "Administration",
+                ["Obama", "Trump 1", "Biden", "Trump 2"],
+            )
+            doc_type_filter = st.multiselect(
+                "Document Type",
+                ["RULE", "PROPOSED_RULE", "NOTICE"],
+            )
+        with col2:
+            date_from = st.date_input("From date", value=None)
+            date_to = st.date_input("To date", value=None)
+
+    filters: dict = {}
+    if admin_filter:
+        filters["administration"] = admin_filter
+    if doc_type_filter:
+        filters["document_type"] = doc_type_filter
+    if date_from:
+        filters["date_from"] = date_from
+    if date_to:
+        filters["date_to"] = date_to
+
+    if st.button("Search") or query:
+        session = _get_session()
+        try:
+            results = search_rules(session, query=query, filters=filters)
+        finally:
+            session.close()
+
+        if not results:
+            st.info("No results found.")
+        else:
+            st.caption(f"{len(results)} results")
+            for r in results:
+                admin_color = ADMIN_COLORS.get(r["administration"], "#6c7086")
+                doc_color = DOC_TYPE_COLORS.get(r["document_type"], "#6c7086")
+                with st.container(border=True):
+                    col_title, col_badges = st.columns([4, 1])
+                    with col_title:
+                        if st.button(r["title"], key=str(r["rule_id"])):
+                            st.session_state["selected_rule_id"] = str(r["rule_id"])
+                            st.session_state["nav_to_detail"] = True
+                            st.rerun()
+                    with col_badges:
+                        st.markdown(
+                            f"<span style='background:{admin_color};color:#1e1e2e;"
+                            f"padding:2px 8px;border-radius:4px;font-size:0.8em'>"
+                            f"{r['administration']}</span> "
+                            f"<span style='background:{doc_color};color:#1e1e2e;"
+                            f"padding:2px 8px;border-radius:4px;font-size:0.8em'>"
+                            f"{r['document_type']}</span>",
+                            unsafe_allow_html=True,
+                        )
+                    if r.get("abstract"):
+                        st.caption(r["abstract"][:200] + ("..." if len(r["abstract"] or "") > 200 else ""))
+                    meta_parts = [str(r["publication_date"])]
+                    if r.get("cfr_sections"):
+                        meta_parts.append(" · ".join(r["cfr_sections"]))
+                    st.caption(" · ".join(meta_parts))
+
+# --- Rule Detail view ---
+
+elif view == "Rule Detail":
+    st.title("Rule Detail")
+
+    rule_id_str = st.session_state.get("selected_rule_id")
+    if not rule_id_str:
+        st.info("Select a rule from the Search view to see its details.")
+    else:
+        session = _get_session()
+        try:
+            rule = get_rule(session, uuid.UUID(rule_id_str))
+        finally:
+            session.close()
+
+        if rule is None:
+            st.error("Rule not found.")
+        else:
+            st.header(rule["title"])
+
+            col1, col2, col3, col4 = st.columns(4)
+            col1.metric("Date", str(rule["publication_date"]))
+            col2.metric("Administration", rule["administration"])
+            col3.metric("Type", rule["document_type"])
+            col4.markdown(f"[Federal Register]({rule['fr_url']})")
+
+            if rule.get("cfr_sections"):
+                st.markdown("**CFR Sections:** " + ", ".join(rule["cfr_sections"]))
+
+            if rule.get("abstract"):
+                st.subheader("Abstract")
+                st.write(rule["abstract"])
+
+            with st.expander("Full Text"):
+                st.write(rule["full_text"])
+
+            st.subheader("Citation Graph")
+            st.info("Citation graph coming soon — pending citation extraction implementation.")
+
+# --- Administration Comparison view ---
+
+elif view == "Administration Comparison":
+    st.title("Administration Comparison")
+
+    session = _get_session()
+    try:
+        data = get_admin_comparison(session)
+    finally:
+        session.close()
+
+    if not data["counts_by_admin"]:
+        st.info("No rules in the database yet.")
+    else:
+        # Metric cards
+        cols = st.columns(len(data["admin_spans"]))
+        for i, span in enumerate(data["admin_spans"]):
+            count = data["counts_by_admin"].get(span["name"], 0)
+            cols[i].metric(span["name"], count)
+
+        # Stacked bar chart
+        admin_names = [s["name"] for s in data["admin_spans"]]
+        doc_types = sorted({dt for _, dt in data["counts_by_admin_type"]})
+
+        fig = go.Figure()
+        for dt in doc_types:
+            counts = [
+                data["counts_by_admin_type"].get((admin, dt), 0)
+                for admin in admin_names
+            ]
+            fig.update_layout(barmode="stack")
+            fig.add_trace(go.Bar(
+                name=dt,
+                x=admin_names,
+                y=counts,
+                marker_color=DOC_TYPE_COLORS.get(dt, "#6c7086"),
+            ))
+        fig.update_layout(
+            title="Rules by Type per Administration",
+            barmode="stack",
+            xaxis_title="Administration",
+            yaxis_title="Count",
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+        # Timeline
+        fig_timeline = go.Figure()
+        for span in data["admin_spans"]:
+            count = data["counts_by_admin"].get(span["name"], 0)
+            fig_timeline.add_trace(go.Bar(
+                name=span["name"],
+                x=[(span["end"] - span["start"]).days],
+                y=[span["name"]],
+                orientation="h",
+                marker_color=ADMIN_COLORS.get(span["name"], "#6c7086"),
+                text=[f"{count} rules"],
+                textposition="inside",
+            ))
+        fig_timeline.update_layout(
+            title="Administration Timeline",
+            showlegend=False,
+            barmode="stack",
+            xaxis_title="Days in Office",
+        )
+        st.plotly_chart(fig_timeline, use_container_width=True)
+
+        # Topic drift stub
+        st.subheader("Topic Drift")
+        st.info("Topic drift analysis coming soon — pending embedding centroid computation.")
+
+# --- Graph Explorer view ---
+
+elif view == "Graph Explorer":
+    st.title("Graph Explorer")
+    st.info(
+        "Citation graph coming soon — this view will show the full FERC rule citation "
+        "network, filterable by administration and document type."
+    )
+
+# --- Handle nav-to-detail redirect ---
+
+if st.session_state.get("nav_to_detail"):
+    st.session_state["nav_to_detail"] = False
+```
+
+- [ ] **Step 2: Smoke test the app**
+
+Run:
+```bash
+uv run streamlit run app.py
+```
+
+Open the browser URL. Verify:
+- Sidebar shows 4 navigation options
+- Search view renders with search bar and filter expander
+- Administration Comparison shows charts (if DB has data) or "No rules" message
+- Rule Detail shows "Select a rule" prompt
+- Graph Explorer shows "coming soon" stub
+
+Stop the server with `Ctrl+C`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app.py
+git commit -m "feat: add Streamlit UI shell with all 4 views"
+```
+
+---
+
+### Task 7: Add hybrid search with pgvector (integration test)
+
+**Files:**
+- Modify: `src/trace_app/frontend/search.py`
+- Create: `tests/integration/test_frontend_search.py`
+
+Keyword search works on SQLite. This task adds the semantic (cosine similarity) path that only works on Postgres+pgvector, behind an optional `embed_fn` parameter.
+
+- [ ] **Step 1: Write integration test**
+
+Create `tests/integration/test_frontend_search.py`:
+
+```python
+"""Integration tests for hybrid search (requires Postgres + pgvector)."""
+
+import uuid
+from datetime import UTC, date, datetime
+
+import pytest
+from sentence_transformers import SentenceTransformer
+
+from trace_app.frontend.search import search_rules_hybrid
+from trace_app.storage.models import Rule
+
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+
+def _embed(text: str) -> list[float]:
+    return model.encode(text).tolist()
+
+
+def _make_rule(**overrides) -> Rule:
+    defaults = dict(
+        rule_id=uuid.uuid4(),
+        title="Test Rule",
+        abstract="An abstract about electricity markets.",
+        full_text="Full body text about FERC regulations.",
+        publication_date=date(2021, 6, 1),
+        agency="FERC",
+        document_type="RULE",
+        administration="Biden",
+        fr_url="https://www.federalregister.gov/documents/2021/06/01/2021-11111/test",
+        fr_document_number=f"2021-{uuid.uuid4().hex[:5]}",
+        content_hash=uuid.uuid4().hex,
+        ingested_at=datetime.now(UTC),
+        text_source="html_fallback",
+    )
+    defaults.update(overrides)
+    return Rule(**defaults)
+
+
+@pytest.mark.integration
+def test_hybrid_search_finds_semantic_match(pg_session):
+    rule = _make_rule(
+        title="Natural Gas Pipeline Safety Standards",
+        abstract="Regulations governing the safety of interstate natural gas pipelines.",
+        embedding=_embed("Natural Gas Pipeline Safety Standards"),
+    )
+    pg_session.add(rule)
+    pg_session.flush()
+
+    results = search_rules_hybrid(
+        pg_session,
+        query="pipeline safety regulations",
+        filters={},
+        embed_fn=_embed,
+    )
+    assert len(results) >= 1
+    assert results[0]["title"] == "Natural Gas Pipeline Safety Standards"
+
+
+@pytest.mark.integration
+def test_hybrid_search_dedupes_keyword_and_semantic(pg_session):
+    rule = _make_rule(
+        title="Pipeline Safety Standards",
+        abstract="Safety standards for natural gas pipelines.",
+        embedding=_embed("Pipeline Safety Standards"),
+    )
+    pg_session.add(rule)
+    pg_session.flush()
+
+    results = search_rules_hybrid(
+        pg_session,
+        query="pipeline safety",
+        filters={},
+        embed_fn=_embed,
+    )
+    rule_ids = [r["rule_id"] for r in results]
+    assert len(rule_ids) == len(set(rule_ids))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/integration/test_frontend_search.py -v -m integration`
+Expected: FAIL — `ImportError: cannot import name 'search_rules_hybrid'`
+
+- [ ] **Step 3: Implement `search_rules_hybrid`**
+
+Add to `src/trace_app/frontend/search.py`. First, add `Callable` to the imports at the top of the file:
+
+```python
+from collections.abc import Callable
+```
+
+Then add the function:
+
+```python
+def search_rules_hybrid(
+    session: Session,
+    query: str,
+    filters: dict,
+    embed_fn: Callable[[str], list[float]],
+    limit: int = 20,
+) -> list[dict]:
+    """Hybrid search: union of keyword ILIKE + pgvector cosine similarity.
+
+    Results are deduped by rule_id, keeping the higher-ranked occurrence.
+    """
+    keyword_results = search_rules(session, query, filters, limit=limit)
+
+    semantic_results: list[dict] = []
+    if query.strip():
+        query_embedding = embed_fn(query.strip())
+        stmt = select(Rule).where(Rule.embedding.isnot(None))
+
+        if admins := filters.get("administration"):
+            stmt = stmt.where(Rule.administration.in_(admins))
+        if doc_types := filters.get("document_type"):
+            stmt = stmt.where(Rule.document_type.in_(doc_types))
+        if date_from := filters.get("date_from"):
+            stmt = stmt.where(Rule.publication_date >= date_from)
+        if date_to := filters.get("date_to"):
+            stmt = stmt.where(Rule.publication_date <= date_to)
+
+        stmt = stmt.order_by(
+            Rule.embedding.cosine_distance(query_embedding)
+        ).limit(limit)
+
+        rules = session.execute(stmt).scalars().all()
+        semantic_results = [_rule_to_dict(r) for r in rules]
+
+    # Union + dedupe: keyword results first, then semantic results for new rule_ids
+    seen_ids = set()
+    merged = []
+    for r in keyword_results + semantic_results:
+        if r["rule_id"] not in seen_ids:
+            seen_ids.add(r["rule_id"])
+            merged.append(r)
+
+    return merged[:limit]
+```
+
+- [ ] **Step 4: Update `app.py` to use hybrid search**
+
+In `app.py`, update the search section. Replace:
+
+```python
+            results = search_rules(session, query=query, filters=filters)
+```
+
+With:
+
+```python
+            embed_model = _get_embed_model()
+            results = search_rules_hybrid(
+                session,
+                query=query,
+                filters=filters,
+                embed_fn=lambda text: embed_model.encode(text).tolist(),
+            )
+```
+
+And update the import at the top of `app.py`:
+
+```python
+from trace_app.frontend.search import get_rule, search_rules_hybrid
+```
+
+(Remove `search_rules` from the import since `app.py` no longer calls it directly.)
+
+- [ ] **Step 5: Run integration tests**
+
+Run: `uv run pytest tests/integration/test_frontend_search.py -v -m integration`
+Expected: 2 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/trace_app/frontend/search.py tests/integration/test_frontend_search.py app.py
+git commit -m "feat: add hybrid search with pgvector cosine similarity"
+```
+
+---
+
+### Task 8: Update roadmap and final verification
+
+**Files:**
+- Modify: `docs/roadmap.md`
+
+- [ ] **Step 1: Update roadmap to reflect phase reordering**
+
+In `docs/roadmap.md`, renumber the phases:
+- Phase 3 → Streamlit UI (was Phase 4)
+- Phase 4 → Citation Graph (was Phase 3)
+- Phase 5 → LangGraph Agent (unchanged)
+
+Mark Phase 3 (Streamlit UI) with ✅.
+
+- [ ] **Step 2: Run full test suite**
+
+Run:
+```bash
+uv run pytest tests/unit/ -v
+```
+Expected: all unit tests pass (existing + new).
+
+- [ ] **Step 3: Run linting**
+
+Run:
+```bash
+uv run ruff check src/ tests/ app.py
+uv run ruff format src/ tests/ app.py
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/roadmap.md
+git commit -m "docs: reorder roadmap phases, mark Streamlit UI complete"
+```

--- a/docs/superpowers/specs/2026-04-13-streamlit-ui-design.md
+++ b/docs/superpowers/specs/2026-04-13-streamlit-ui-design.md
@@ -1,0 +1,91 @@
+# Streamlit UI Design
+
+## Goal
+
+Browser interface for search, rule detail, citation graph (stubbed), and administration comparison over the FERC rule corpus.
+
+## Architecture
+
+**Entry point:** `app.py` at the project root — thin Streamlit rendering shell, zero business logic.
+
+**Data layer:** `src/trace_app/frontend/` — framework-agnostic query functions returning plain Python dicts/lists. **No Streamlit imports allowed.** This constraint ensures the data layer can be reused with FastHTML, React+FastAPI, or any other frontend.
+
+**DB access:** Single `SessionFactory` via `@st.cache_resource` in `app.py`, passed into frontend functions.
+
+### File layout
+
+```
+app.py
+src/trace_app/frontend/
+  __init__.py
+  search.py        # search_rules(), get_rule()
+  comparison.py    # get_admin_comparison()
+  graph.py         # stub — get_citation_subgraph(), get_full_graph()
+```
+
+## Views
+
+### Navigation
+
+Sidebar (`st.sidebar`) with radio selection across 4 views. Persistent left panel.
+
+### Search (default landing page)
+
+- Search bar + button at top
+- Collapsible filter expander below bar: agency, document type (multiselect), administration (multiselect), date range
+- Hybrid query: keyword `ILIKE` on title+abstract + pgvector cosine similarity on query embedding, results merged and deduped by `rule_id`, top 20
+- Results: vertical stack of cards — title, administration badge (color-coded per era), document type badge, date, CFR sections, highlighted abstract snippet
+- Clicking a result navigates to Rule Detail via `st.session_state`
+
+### Rule Detail
+
+- Navigated from Search (rule_id in session state) or directly via sidebar
+- Title, metadata row (date, administration, document type, CFR sections, FR link)
+- Full abstract, full text in expander
+- Citation subgraph: **stubbed** — "Citation graph coming soon" placeholder
+
+### Administration Comparison
+
+- Stacked bar chart (Plotly) — rule count by document type per administration
+- Row of 4 metric cards — total rule count per administration, color-coded per era
+- Topic drift: **stubbed** — "Topic drift analysis coming soon" placeholder
+- Timeline: Plotly bar showing each administration's span and rule volume
+
+### Graph Explorer
+
+- Fully **stubbed** — "Citation graph coming soon" placeholder
+
+## Data Layer
+
+### `search.py`
+
+- `search_rules(session, query, filters) -> list[dict]` — ILIKE on title+abstract, pgvector cosine similarity on query embedding, union both result sets, dedupe by `rule_id` keeping the higher-ranked occurrence, return top 20 ordered by combined relevance
+- `get_rule(session, rule_id) -> dict` — single rule by ID
+
+### `comparison.py`
+
+- `get_admin_comparison(session) -> dict` — rule counts grouped by administration + document type, plus administration date spans for timeline
+
+### `graph.py`
+
+- `get_citation_subgraph(session, rule_id) -> dict` — stub, returns `{"stub": True}`
+- `get_full_graph(session) -> dict` — stub, returns `{"stub": True}`
+
+### Embedding
+
+Query string embedded at search time using `all-MiniLM-L6-v2`, model loaded once via `@st.cache_resource`.
+
+## Key decisions
+
+- Plotly only (no Pyvis) — per CLAUDE.md
+- All DB access through SQLAlchemy sessions; no raw SQL in UI layer
+- No authentication — internal tool
+- `frontend/` module has zero Streamlit imports — pure data/query layer for framework portability
+- Citation graph views stubbed pending Phase 3 implementation
+
+## Testing
+
+- Unit tests for all `frontend/` functions using SQLite in-memory
+- Test cases: search with no results, keyword-only match, search with filters, `get_rule` valid/missing ID, `get_admin_comparison` with empty DB
+- No Streamlit rendering tested — `app.py` is not unit tested
+- Integration tests (`@pytest.mark.integration`) for hybrid search against Postgres+pgvector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "beautifulsoup4>=4.12,<5.0",
     "lxml>=5.0,<6.0",
     "prefect>=3.0,<4.0",
+    "plotly>=6.0,<7.0",
+    "streamlit>=1.40,<2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/trace_app/frontend/comparison.py
+++ b/src/trace_app/frontend/comparison.py
@@ -1,0 +1,48 @@
+"""Administration comparison queries — framework-agnostic, no Streamlit imports."""
+
+from collections import defaultdict
+from datetime import date
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from trace_app.storage.models import Rule
+
+ADMIN_SPANS = [
+    {"name": "Obama", "start": date(2009, 1, 20), "end": date(2017, 1, 19)},
+    {"name": "Trump 1", "start": date(2017, 1, 20), "end": date(2021, 1, 19)},
+    {"name": "Biden", "start": date(2021, 1, 20), "end": date(2025, 1, 19)},
+    {"name": "Trump 2", "start": date(2025, 1, 20), "end": date(2029, 1, 19)},
+]
+
+
+def get_admin_comparison(session: Session) -> dict:
+    """Return rule counts and breakdowns by administration.
+
+    Returns:
+        {
+            "counts_by_admin": {"Biden": 42, ...},
+            "counts_by_admin_type": {("Biden", "RULE"): 30, ...},
+            "admin_spans": [{"name": ..., "start": ..., "end": ...}, ...],
+        }
+    """
+    rows = session.execute(
+        select(
+            Rule.administration,
+            Rule.document_type,
+            func.count().label("cnt"),
+        ).group_by(Rule.administration, Rule.document_type)
+    ).all()
+
+    counts_by_admin: dict[str, int] = defaultdict(int)
+    counts_by_admin_type: dict[tuple[str, str], int] = {}
+
+    for admin, doc_type, cnt in rows:
+        counts_by_admin[admin] += cnt
+        counts_by_admin_type[(admin, doc_type)] = cnt
+
+    return {
+        "counts_by_admin": dict(counts_by_admin),
+        "counts_by_admin_type": counts_by_admin_type,
+        "admin_spans": ADMIN_SPANS,
+    }

--- a/src/trace_app/frontend/graph.py
+++ b/src/trace_app/frontend/graph.py
@@ -1,0 +1,15 @@
+"""Citation graph queries — stubs pending citation graph implementation."""
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+
+def get_citation_subgraph(session: Session, rule_id: uuid.UUID) -> dict:
+    """Return 1-hop citation subgraph for a rule. Stub."""
+    return {"stub": True}
+
+
+def get_full_graph(session: Session) -> dict:
+    """Return the full citation graph. Stub."""
+    return {"stub": True}

--- a/src/trace_app/frontend/search.py
+++ b/src/trace_app/frontend/search.py
@@ -1,6 +1,7 @@
 """Search and rule retrieval — framework-agnostic, no Streamlit imports."""
 
 import uuid
+from collections.abc import Callable
 
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
@@ -67,3 +68,46 @@ def search_rules(
     stmt = stmt.order_by(Rule.publication_date.desc()).limit(limit)
     rules = session.execute(stmt).scalars().all()
     return [_rule_to_dict(r) for r in rules]
+
+
+def search_rules_hybrid(
+    session: Session,
+    query: str,
+    filters: dict,
+    embed_fn: Callable[[str], list[float]],
+    limit: int = 20,
+) -> list[dict]:
+    """Hybrid search: union of keyword ILIKE + pgvector cosine similarity.
+
+    Results are deduped by rule_id, keeping the higher-ranked occurrence.
+    """
+    keyword_results = search_rules(session, query, filters, limit=limit)
+
+    semantic_results: list[dict] = []
+    if query.strip():
+        query_embedding = embed_fn(query.strip())
+        stmt = select(Rule).where(Rule.embedding.isnot(None))
+
+        if admins := filters.get("administration"):
+            stmt = stmt.where(Rule.administration.in_(admins))
+        if doc_types := filters.get("document_type"):
+            stmt = stmt.where(Rule.document_type.in_(doc_types))
+        if date_from := filters.get("date_from"):
+            stmt = stmt.where(Rule.publication_date >= date_from)
+        if date_to := filters.get("date_to"):
+            stmt = stmt.where(Rule.publication_date <= date_to)
+
+        stmt = stmt.order_by(Rule.embedding.cosine_distance(query_embedding)).limit(limit)
+
+        rules = session.execute(stmt).scalars().all()
+        semantic_results = [_rule_to_dict(r) for r in rules]
+
+    # Union + dedupe: keyword results first, then semantic results for new rule_ids
+    seen_ids = set()
+    merged = []
+    for r in keyword_results + semantic_results:
+        if r["rule_id"] not in seen_ids:
+            seen_ids.add(r["rule_id"])
+            merged.append(r)
+
+    return merged[:limit]

--- a/src/trace_app/frontend/search.py
+++ b/src/trace_app/frontend/search.py
@@ -1,0 +1,34 @@
+"""Search and rule retrieval — framework-agnostic, no Streamlit imports."""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from trace_app.storage.models import Rule
+
+
+def _rule_to_dict(rule: Rule) -> dict:
+    return {
+        "rule_id": rule.rule_id,
+        "title": rule.title,
+        "abstract": rule.abstract,
+        "full_text": rule.full_text,
+        "publication_date": rule.publication_date,
+        "effective_date": rule.effective_date,
+        "agency": rule.agency,
+        "document_type": rule.document_type,
+        "cfr_sections": rule.cfr_sections,
+        "administration": rule.administration,
+        "fr_url": rule.fr_url,
+        "fr_document_number": rule.fr_document_number,
+        "text_source": rule.text_source,
+    }
+
+
+def get_rule(session: Session, rule_id: uuid.UUID) -> dict | None:
+    """Fetch a single rule by ID. Returns dict or None."""
+    rule = session.execute(select(Rule).where(Rule.rule_id == rule_id)).scalar_one_or_none()
+    if rule is None:
+        return None
+    return _rule_to_dict(rule)

--- a/src/trace_app/frontend/search.py
+++ b/src/trace_app/frontend/search.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 from trace_app.storage.models import Rule
@@ -32,3 +32,38 @@ def get_rule(session: Session, rule_id: uuid.UUID) -> dict | None:
     if rule is None:
         return None
     return _rule_to_dict(rule)
+
+
+def search_rules(
+    session: Session,
+    query: str,
+    filters: dict,
+    limit: int = 20,
+) -> list[dict]:
+    """Keyword search on title+abstract with optional filters."""
+    stmt = select(Rule)
+
+    if query.strip():
+        pattern = f"%{query.strip()}%"
+        stmt = stmt.where(
+            or_(
+                Rule.title.ilike(pattern),
+                Rule.abstract.ilike(pattern),
+            )
+        )
+
+    if admins := filters.get("administration"):
+        stmt = stmt.where(Rule.administration.in_(admins))
+
+    if doc_types := filters.get("document_type"):
+        stmt = stmt.where(Rule.document_type.in_(doc_types))
+
+    if date_from := filters.get("date_from"):
+        stmt = stmt.where(Rule.publication_date >= date_from)
+
+    if date_to := filters.get("date_to"):
+        stmt = stmt.where(Rule.publication_date <= date_to)
+
+    stmt = stmt.order_by(Rule.publication_date.desc()).limit(limit)
+    rules = session.execute(stmt).scalars().all()
+    return [_rule_to_dict(r) for r in rules]

--- a/tests/integration/test_frontend_search.py
+++ b/tests/integration/test_frontend_search.py
@@ -1,0 +1,76 @@
+"""Integration tests for hybrid search (requires Postgres + pgvector)."""
+
+import uuid
+from datetime import UTC, date, datetime
+
+import pytest
+from sentence_transformers import SentenceTransformer
+
+from trace_app.frontend.search import search_rules_hybrid
+from trace_app.storage.models import Rule
+
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+
+def _embed(text: str) -> list[float]:
+    return model.encode(text).tolist()
+
+
+def _make_rule(**overrides) -> Rule:
+    defaults = dict(
+        rule_id=uuid.uuid4(),
+        title="Test Rule",
+        abstract="An abstract about electricity markets.",
+        full_text="Full body text about FERC regulations.",
+        publication_date=date(2021, 6, 1),
+        agency="FERC",
+        document_type="RULE",
+        administration="Biden",
+        fr_url="https://www.federalregister.gov/documents/2021/06/01/2021-11111/test",
+        fr_document_number=f"2021-{uuid.uuid4().hex[:5]}",
+        content_hash=uuid.uuid4().hex,
+        ingested_at=datetime.now(UTC),
+        text_source="html_fallback",
+    )
+    defaults.update(overrides)
+    return Rule(**defaults)
+
+
+@pytest.mark.integration
+def test_hybrid_search_finds_semantic_match(pg_session):
+    rule = _make_rule(
+        title="Natural Gas Pipeline Safety Standards",
+        abstract="Regulations governing the safety of interstate natural gas pipelines.",
+        embedding=_embed("Natural Gas Pipeline Safety Standards"),
+    )
+    pg_session.add(rule)
+    pg_session.flush()
+
+    results = search_rules_hybrid(
+        pg_session,
+        query="pipeline safety regulations",
+        filters={},
+        embed_fn=_embed,
+    )
+    assert len(results) >= 1
+    assert results[0]["title"] == "Natural Gas Pipeline Safety Standards"
+
+
+@pytest.mark.integration
+def test_hybrid_search_dedupes_keyword_and_semantic(pg_session):
+    rule = _make_rule(
+        title="Pipeline Safety Standards",
+        abstract="Safety standards for natural gas pipelines.",
+        embedding=_embed("Pipeline Safety Standards"),
+    )
+    pg_session.add(rule)
+    pg_session.flush()
+
+    results = search_rules_hybrid(
+        pg_session,
+        query="pipeline safety",
+        filters={},
+        embed_fn=_embed,
+    )
+    rule_ids = [r["rule_id"] for r in results]
+    assert len(rule_ids) == len(set(rule_ids))

--- a/tests/unit/test_frontend_comparison.py
+++ b/tests/unit/test_frontend_comparison.py
@@ -1,0 +1,94 @@
+"""Unit tests for administration comparison functions (SQLite)."""
+
+import uuid
+from datetime import UTC, date, datetime
+
+from trace_app.storage.models import Rule
+
+
+def _make_rule(**overrides) -> Rule:
+    defaults = dict(
+        rule_id=uuid.uuid4(),
+        title="Test Rule",
+        abstract="Abstract text.",
+        full_text="Full body text.",
+        publication_date=date(2021, 6, 1),
+        agency="FERC",
+        document_type="RULE",
+        administration="Biden",
+        fr_url="https://www.federalregister.gov/documents/2021/06/01/2021-11111/test",
+        fr_document_number="2021-11111",
+        content_hash="abc123",
+        ingested_at=datetime.now(UTC),
+        text_source="html_fallback",
+    )
+    defaults.update(overrides)
+    return Rule(**defaults)
+
+
+def test_get_admin_comparison_empty_db(sqlite_session):
+    from trace_app.frontend.comparison import get_admin_comparison
+
+    result = get_admin_comparison(sqlite_session)
+    assert result["counts_by_admin"] == {}
+    assert result["counts_by_admin_type"] == {}
+
+
+def test_get_admin_comparison_counts_by_admin(sqlite_session):
+    r1 = _make_rule(
+        administration="Biden",
+        fr_document_number="2021-11111",
+        content_hash="h1",
+    )
+    r2 = _make_rule(
+        administration="Biden",
+        fr_document_number="2021-22222",
+        content_hash="h2",
+        document_type="NOTICE",
+    )
+    r3 = _make_rule(
+        administration="Trump 1",
+        fr_document_number="2019-33333",
+        content_hash="h3",
+    )
+    sqlite_session.add_all([r1, r2, r3])
+    sqlite_session.flush()
+
+    from trace_app.frontend.comparison import get_admin_comparison
+
+    result = get_admin_comparison(sqlite_session)
+    assert result["counts_by_admin"]["Biden"] == 2
+    assert result["counts_by_admin"]["Trump 1"] == 1
+
+
+def test_get_admin_comparison_counts_by_admin_type(sqlite_session):
+    r1 = _make_rule(
+        administration="Biden",
+        document_type="RULE",
+        fr_document_number="2021-11111",
+        content_hash="h1",
+    )
+    r2 = _make_rule(
+        administration="Biden",
+        document_type="NOTICE",
+        fr_document_number="2021-22222",
+        content_hash="h2",
+    )
+    sqlite_session.add_all([r1, r2])
+    sqlite_session.flush()
+
+    from trace_app.frontend.comparison import get_admin_comparison
+
+    result = get_admin_comparison(sqlite_session)
+    assert result["counts_by_admin_type"][("Biden", "RULE")] == 1
+    assert result["counts_by_admin_type"][("Biden", "NOTICE")] == 1
+
+
+def test_get_admin_comparison_includes_admin_spans(sqlite_session):
+    from trace_app.frontend.comparison import get_admin_comparison
+
+    result = get_admin_comparison(sqlite_session)
+    spans = result["admin_spans"]
+    assert len(spans) == 4
+    assert spans[0]["name"] == "Obama"
+    assert spans[-1]["name"] == "Trump 2"

--- a/tests/unit/test_frontend_graph.py
+++ b/tests/unit/test_frontend_graph.py
@@ -1,0 +1,17 @@
+"""Unit tests for graph stubs."""
+
+import uuid
+
+
+def test_get_citation_subgraph_returns_stub(sqlite_session):
+    from trace_app.frontend.graph import get_citation_subgraph
+
+    result = get_citation_subgraph(sqlite_session, uuid.uuid4())
+    assert result == {"stub": True}
+
+
+def test_get_full_graph_returns_stub(sqlite_session):
+    from trace_app.frontend.graph import get_full_graph
+
+    result = get_full_graph(sqlite_session)
+    assert result == {"stub": True}

--- a/tests/unit/test_frontend_search.py
+++ b/tests/unit/test_frontend_search.py
@@ -44,3 +44,105 @@ def test_get_rule_returns_none_for_missing_id(sqlite_session):
 
     result = get_rule(sqlite_session, uuid.uuid4())
     assert result is None
+
+
+def test_search_rules_keyword_matches_title(sqlite_session):
+    rule = _make_rule(title="Electricity Transmission Rates")
+    sqlite_session.add(rule)
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(sqlite_session, query="transmission", filters={})
+    assert len(results) == 1
+    assert results[0]["title"] == "Electricity Transmission Rates"
+
+
+def test_search_rules_keyword_matches_abstract(sqlite_session):
+    rule = _make_rule(abstract="Wholesale electricity market reform")
+    sqlite_session.add(rule)
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(sqlite_session, query="wholesale", filters={})
+    assert len(results) == 1
+
+
+def test_search_rules_no_match_returns_empty(sqlite_session):
+    rule = _make_rule()
+    sqlite_session.add(rule)
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(sqlite_session, query="nonexistent_xyz", filters={})
+    assert results == []
+
+
+def test_search_rules_filters_by_administration(sqlite_session):
+    r1 = _make_rule(
+        administration="Biden",
+        fr_document_number="2021-11111",
+        content_hash="hash1",
+    )
+    r2 = _make_rule(
+        administration="Trump 1",
+        fr_document_number="2019-22222",
+        content_hash="hash2",
+        title="Another Rule",
+    )
+    sqlite_session.add_all([r1, r2])
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(
+        sqlite_session,
+        query="rule",
+        filters={"administration": ["Biden"]},
+    )
+    assert len(results) == 1
+    assert results[0]["administration"] == "Biden"
+
+
+def test_search_rules_filters_by_document_type(sqlite_session):
+    r1 = _make_rule(
+        document_type="RULE",
+        fr_document_number="2021-11111",
+        content_hash="hash1",
+    )
+    r2 = _make_rule(
+        document_type="NOTICE",
+        fr_document_number="2021-22222",
+        content_hash="hash2",
+        title="A Notice",
+    )
+    sqlite_session.add_all([r1, r2])
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(
+        sqlite_session,
+        query="",
+        filters={"document_type": ["RULE"]},
+    )
+    assert len(results) == 1
+    assert results[0]["document_type"] == "RULE"
+
+
+def test_search_rules_empty_query_returns_all(sqlite_session):
+    r1 = _make_rule(fr_document_number="2021-11111", content_hash="hash1")
+    r2 = _make_rule(
+        fr_document_number="2021-22222",
+        content_hash="hash2",
+        title="Second Rule",
+    )
+    sqlite_session.add_all([r1, r2])
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import search_rules
+
+    results = search_rules(sqlite_session, query="", filters={})
+    assert len(results) == 2

--- a/tests/unit/test_frontend_search.py
+++ b/tests/unit/test_frontend_search.py
@@ -1,0 +1,46 @@
+"""Unit tests for frontend search functions (SQLite)."""
+
+import uuid
+from datetime import UTC, date, datetime
+
+from trace_app.storage.models import Rule
+
+
+def _make_rule(**overrides) -> Rule:
+    defaults = dict(
+        rule_id=uuid.uuid4(),
+        title="Test Rule",
+        abstract="An abstract about electricity markets.",
+        full_text="Full body text about FERC regulations.",
+        publication_date=date(2021, 6, 1),
+        agency="FERC",
+        document_type="RULE",
+        administration="Biden",
+        fr_url="https://www.federalregister.gov/documents/2021/06/01/2021-11111/test",
+        fr_document_number="2021-11111",
+        content_hash="abc123",
+        ingested_at=datetime.now(UTC),
+        text_source="html_fallback",
+    )
+    defaults.update(overrides)
+    return Rule(**defaults)
+
+
+def test_get_rule_returns_matching_rule(sqlite_session):
+    rule = _make_rule()
+    sqlite_session.add(rule)
+    sqlite_session.flush()
+
+    from trace_app.frontend.search import get_rule
+
+    result = get_rule(sqlite_session, rule.rule_id)
+    assert result is not None
+    assert result["title"] == "Test Rule"
+    assert result["rule_id"] == rule.rule_id
+
+
+def test_get_rule_returns_none_for_missing_id(sqlite_session):
+    from trace_app.frontend.search import get_rule
+
+    result = get_rule(sqlite_session, uuid.uuid4())
+    assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -27,6 +31,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
+name = "altair"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/c0/184a89bd5feba14ff3c41cfaf1dd8a82c05f5ceedbc92145e17042eb08a4/altair-6.0.0.tar.gz", hash = "sha256:614bf5ecbe2337347b590afb111929aa9c16c9527c4887d96c9bc7f6640756b4", size = 763834, upload-time = "2025-11-12T08:59:11.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/33/ef2f2409450ef6daa61459d5de5c08128e7d3edb773fefd0a324d1310238/altair-6.0.0-py3-none-any.whl", hash = "sha256:09ae95b53d5fe5b16987dccc785a7af8588f2dca50de1e7a156efa8a461515f8", size = 795410, upload-time = "2025-11-12T08:59:09.804Z" },
 ]
 
 [[package]]
@@ -152,6 +172,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
 
 [[package]]
@@ -595,6 +624,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
 ]
 
 [[package]]
@@ -1078,6 +1131,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/1a/bd3317c0bdbcd9ffb710ddf5250b32898f8f2c240be99494fe137feb77a7/narwhals-2.19.0.tar.gz", hash = "sha256:14fd7040b5ff211d415a82e4827b9d04c354e213e72a6d0730205ffd72e3b7ff", size = 623698, upload-time = "2026-04-06T15:50:58.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl", hash = "sha256:1f8dfa4a33a6dbff878c3e9be4c3b455dfcaf2a9322f1357db00e4e92e95b84b", size = 446991, upload-time = "2026-04-06T15:50:57.046Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1354,6 +1416,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
+    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,6 +1559,19 @@ wheels = [
 ]
 
 [[package]]
+name = "plotly"
+version = "6.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/7f/0f100df1172aadf88a929a9dbb902656b0880ba4b960fe5224867159d8f4/plotly-6.7.0.tar.gz", hash = "sha256:45eea0ff27e2a23ccd62776f77eb43aa1ca03df4192b76036e380bb479b892c6", size = 6911286, upload-time = "2026-04-09T20:36:45.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl", hash = "sha256:ac8aca1c25c663a59b5b9140a549264a5badde2e057d79b8c772ae2920e32ff0", size = 9898444, upload-time = "2026-04-09T20:36:39.812Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1562,6 +1673,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
 name = "psycopg"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1627,6 +1753,35 @@ memory = [
 ]
 redis = [
     { name = "redis" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
 ]
 
 [[package]]
@@ -1721,6 +1876,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
+name = "pydeck"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240, upload-time = "2024-05-10T15:36:21.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403, upload-time = "2024-05-10T15:36:17.36Z" },
 ]
 
 [[package]]
@@ -2308,6 +2476,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2386,6 +2563,35 @@ wheels = [
 ]
 
 [[package]]
+name = "streamlit"
+version = "1.56.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altair" },
+    { name = "blinker" },
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "pyarrow" },
+    { name = "pydeck" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "toml" },
+    { name = "tornado" },
+    { name = "typing-extensions" },
+    { name = "watchdog", marker = "sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/85/7c669b3a1336d34ef39fa9760fbd343185f3b15db2ad0838fd78423d1c7f/streamlit-1.56.0.tar.gz", hash = "sha256:1176acfa89ae1318b79078e8efe689a9d02e8d58e325c00fc0e55fa2f3fe8d6a", size = 8559239, upload-time = "2026-03-31T22:29:38.59Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/91/cb6f13a89e376ef179309d74f37a70ea0041d5e4b5ba5c4836dbf6e020ad/streamlit-1.56.0-py3-none-any.whl", hash = "sha256:8677a335734a30a51bc57ad0ec910e365d95f7c456fc02c60032927cd0729dc5", size = 9052089, upload-time = "2026-03-31T22:29:36.342Z" },
+]
+
+[[package]]
 name = "structlog"
 version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2404,6 +2610,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]
@@ -2495,6 +2710,23 @@ wheels = [
 ]
 
 [[package]]
+name = "tornado"
+version = "6.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/f1/3173dfa4a18db4a9b03e5d55325559dab51ee653763bb8745a75af491286/tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9", size = 516006, upload-time = "2026-03-10T21:31:02.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa", size = 445983, upload-time = "2026-03-10T21:30:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521", size = 444246, upload-time = "2026-03-10T21:30:46.571Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5", size = 447229, upload-time = "2026-03-10T21:30:48.273Z" },
+    { url = "https://files.pythonhosted.org/packages/34/01/74e034a30ef59afb4097ef8659515e96a39d910b712a89af76f5e4e1f93c/tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07", size = 448192, upload-time = "2026-03-10T21:30:51.22Z" },
+    { url = "https://files.pythonhosted.org/packages/be/00/fe9e02c5a96429fce1a1d15a517f5d8444f9c412e0bb9eadfbe3b0fc55bf/tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e", size = 448039, upload-time = "2026-03-10T21:30:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9e/656ee4cec0398b1d18d0f1eb6372c41c6b889722641d84948351ae19556d/tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca", size = 447445, upload-time = "2026-03-10T21:30:55.541Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2516,12 +2748,14 @@ dependencies = [
     { name = "httpx" },
     { name = "lxml" },
     { name = "pgvector" },
+    { name = "plotly" },
     { name = "prefect" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "sentence-transformers" },
     { name = "sqlalchemy" },
+    { name = "streamlit" },
     { name = "structlog" },
 ]
 
@@ -2541,6 +2775,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "lxml", specifier = ">=5.0,<6.0" },
     { name = "pgvector", specifier = ">=0.3,<1.0" },
+    { name = "plotly", specifier = ">=6.0,<7.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7,<4.0" },
     { name = "prefect", specifier = ">=3.0,<4.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1,<4.0" },
@@ -2551,6 +2786,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4,<1.0" },
     { name = "sentence-transformers", specifier = ">=3.0,<4.0" },
     { name = "sqlalchemy", specifier = ">=2.0,<3.0" },
+    { name = "streamlit", specifier = ">=1.40,<2.0" },
     { name = "structlog", specifier = ">=24.0,<27.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.0a1" },
 ]
@@ -2715,6 +2951,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds framework-agnostic data layer in `src/trace_app/frontend/` (zero Streamlit imports — ready for future FastHTML/React swap)
- Builds Streamlit shell (`app.py`) with 4 views: Search, Rule Detail, Administration Comparison, Graph Explorer
- Search uses hybrid keyword (ILIKE) + semantic (pgvector cosine similarity) via `all-MiniLM-L6-v2`
- Citation graph views stubbed pending Phase 4 implementation

## Test Plan

- [ ] `uv run pytest tests/unit/ --ignore=tests/unit/test_config.py` — 64 unit tests pass
- [ ] `uv run streamlit run app.py` — UI loads, sidebar nav works, search returns results
- [ ] Search: enter a query, verify hybrid results with admin/doc-type badges appear
- [ ] Administration Comparison: verify stacked bar chart and metric cards render
- [ ] Rule Detail: click a result from Search, verify metadata and full text expander
- [ ] Graph Explorer: verify "coming soon" stub renders
- [ ] Integration tests (requires Postgres): `uv run pytest tests/integration/test_frontend_search.py -m integration`