### PR TITLE
feat: enable DOL (and DOE) ingestion via Federal Register

### DIFF
--- a/src/trace_app/connectors/federal_register.py
+++ b/src/trace_app/connectors/federal_register.py
@@ -27,8 +27,8 @@ FERC = AgencyConfig(
 
 DOE = AgencyConfig(
     agency="energy-department",
-    doc_types=["RULE"],
-    topics=["energy-conservation"],
+    doc_types=["RULE", "PRORULE", "NOTICE", "PRESDOCU"],
+    topics=[],
     name="DOE",
 )
 

--- a/src/trace_app/connectors/ingest.py
+++ b/src/trace_app/connectors/ingest.py
@@ -73,7 +73,7 @@ def ingest_fr(
                 else:
                     try:
                         full_text, text_source = result
-                        rule = parse_fr_document(doc, full_text, text_source)
+                        rule = parse_fr_document(doc, full_text, text_source, agency=config.name)
                         if save_rule(session, rule):
                             inserted += 1
                             print(f"  inserted {doc_number} ({text_source})")

--- a/src/trace_app/processing/rules.py
+++ b/src/trace_app/processing/rules.py
@@ -29,7 +29,9 @@ def compute_content_hash(fr_document_number: str, full_text: str) -> str:
     return hashlib.sha256((fr_document_number + full_text).encode()).hexdigest()
 
 
-def parse_fr_document(doc: dict, full_text: str, text_source: str = "html_fallback") -> Rule:
+def parse_fr_document(
+    doc: dict, full_text: str, text_source: str = "html_fallback", agency: str = "FERC"
+) -> Rule:
     """Parse a Federal Register API document dict into a Rule ORM instance."""
     pub_date = date.fromisoformat(doc["publication_date"])
     effective_date = date.fromisoformat(doc["effective_on"]) if doc.get("effective_on") else None
@@ -45,7 +47,7 @@ def parse_fr_document(doc: dict, full_text: str, text_source: str = "html_fallba
         full_text=full_text,
         publication_date=pub_date,
         effective_date=effective_date,
-        agency="FERC",
+        agency=agency,
         document_type=doc["type"].upper().replace(" ", "_"),
         cfr_sections=cfr_sections,
         administration=get_administration(pub_date),

--- a/tests/integration/test_ingest_fr.py
+++ b/tests/integration/test_ingest_fr.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from trace_app.connectors.federal_register import FERC
+from trace_app.connectors.federal_register import DOL, FERC
 from trace_app.connectors.ingest import ingest_fr
 from trace_app.storage.models import DeadLetter, Rule
 
@@ -99,6 +99,31 @@ def test_ingest_fr_writes_dead_letter_on_error(pg_session):
     assert len(rules) == 0
     assert len(dead) == 1
     assert "Connection timeout" in dead[0].error_message
+
+
+@pytest.mark.integration
+def test_ingest_fr_stores_correct_agency_for_dol(pg_session):
+    with (
+        patch(
+            "trace_app.connectors.ingest.FederalRegisterClient.iter_pages",
+            return_value=iter([SAMPLE_DOCS]),
+        ),
+        patch(
+            "trace_app.connectors.ingest.fetch_full_texts_concurrent",
+            new=AsyncMock(
+                return_value={"2021-11111": ("Full text of the rule.", "html_fallback")}
+            ),
+        ),
+        patch(
+            "trace_app.connectors.ingest.build_engine",
+            return_value=pg_session.get_bind(),
+        ),
+    ):
+        ingest_fr(config=DOL, start_date=date(2021, 1, 1), end_date=date(2021, 12, 31))
+
+    rules = pg_session.query(Rule).all()
+    assert len(rules) == 1
+    assert rules[0].agency == "DOL"
 
 
 @pytest.mark.integration

--- a/tests/unit/test_rules_processing.py
+++ b/tests/unit/test_rules_processing.py
@@ -141,3 +141,8 @@ def test_parse_fr_document_default_text_source():
 def test_parse_fr_document_sets_pdf_docling_source():
     rule = parse_fr_document(SAMPLE_DOC, SAMPLE_FULL_TEXT, text_source="pdf_docling")
     assert rule.text_source == "pdf_docling"
+
+
+def test_parse_fr_document_respects_agency_param():
+    rule = parse_fr_document(SAMPLE_DOC, SAMPLE_FULL_TEXT, agency="DOL")
+    assert rule.agency == "DOL"


### PR DESCRIPTION
## Summary

- `parse_fr_document()` was hardcoding `agency="FERC"` regardless of which `AgencyConfig` was passed to `ingest_fr()`, silently mislabeling all DOL/DOE documents as FERC rules
- Added an `agency` parameter to `parse_fr_document()` (default `"FERC"` for backwards compatibility) and thread `config.name` through the call site in `ingest_fr()`
- Aligned the DOE `AgencyConfig` to match the FERC/DOL pattern (was filtering to `RULE` only with a topic filter, now ingests all doc types)

## What changed

| File | Change |
|------|--------|
| `src/trace_app/processing/rules.py` | Add `agency` param to `parse_fr_document()`, replace hardcoded `"FERC"` |
| `src/trace_app/connectors/ingest.py` | Pass `agency=config.name` at call site |
| `src/trace_app/connectors/federal_register.py` | Standardize DOE config to match FERC/DOL |
| `tests/unit/test_rules_processing.py` | Add `test_parse_fr_document_respects_agency_param` |
| `tests/integration/test_ingest_fr.py` | Add `test_ingest_fr_stores_correct_agency_for_dol` |

## Running DOL ingestion

```
uv run python -m trace_app.connectors.ingest --agency DOL
```

## Reviewer notes

- No migration needed — the `agency` column already exists as a `Text` field
- Default value `"FERC"` keeps all existing FERC ingestion calls working without changes
- DOE ingestion works the same way: `--agency DOE`